### PR TITLE
Feature/dynamic events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ jobs:
         - dotnet build
         - dotnet publish -c release
         - dotnet pack -c release --include-symbols -o publish
-        - for f in publish/*.nupkg ; do dotnet nuget push $f --skip-duplicate -k $NUGET_TOKEN ; done
+        - dotnet nuget push publish/*.nupkg --skip-duplicate -k $NUGET_TOKEN

--- a/docfx_project/articles/event-hub.md
+++ b/docfx_project/articles/event-hub.md
@@ -1,10 +1,10 @@
 # The Event Hub
 
 ## Methodology
-The event hub has been substantially rewritten from its origins in NetIRC but provides similar functionality.  
+The [EventHub](/api/GravyIrc.EventHub.html) has been substantially rewritten from its origins in NetIRC but provides similar functionality.  
 
 ### The Problem
-The original hub had an event for each implementation of `IServerMessage` that was present in the library.  This had the drawbacks of limiting available events to only messages defined within the NetIRC library and added the need for a lot of additional, mostly copy-pasted code to be added for each type of message that is added.  
+The original hub had an event for each implementation of [IServerMessage](/api/GravyIrc.Messages.IServerMessage.html) that was present in the library.  This had the drawbacks of limiting available events to only messages defined within the NetIRC library and added the need for a lot of additional, mostly copy-pasted code to be added for each type of message that is added.  
 
 ### My Approach
 To avoid this shortcomings, I changed the event hub to dynamically create and provide event handlers as needed.  This cuts back on the amount of code that must be added for each type of message and means that users of the library can extend its in-built message types with additional ones at runtime.  My background is in web development with MVC so I'm not especially familiar with C# events.  If you have an idea for a nicer way of handling this, please let me know.  
@@ -17,7 +17,7 @@ myClient.EventHub.Subscribe<PrivateMessage>((client, args) => Console.WriteLine(
 
 ### Registering Additional Message Types
 If the type of message you want to listen for isn't in GravyIrc yet, open a pull request!  Please open a pull request :)
-If you want to extend things on your end, I've made it easy to do that was well.  You'll need a class that implements `IServerMessage` and is decorated with a `ServerMessageAttribute`.
+If you want to extend things on your end, I've made it easy to do that was well.  You'll need a class that implements [IServerMessage](/api/GravyIrc.Messages.IServerMessage.html) and is decorated with a [ServerMessageAttribute](/api/GravyIrc.Attributes.ServerMessageAttribute.html).
 ```csharp
 [ServerMessage("POTATO")]
 public class PotatoMessage : IrcMessage, IServerMessage
@@ -30,8 +30,10 @@ public class PotatoMessage : IrcMessage, IServerMessage
 }
 ```
 
-Once you have your class ready, register it to `IrcMessage` so that incoming messages with that command will be converted to your type and you'll be able to subscribe to events for it.
+Once you have your class ready, register it to [IrcMessage](/api/GravyIrc.Messages.IrcMessage.html) so that incoming messages with that command will be converted to your type and you'll be able to subscribe to events for it.
 ```csharp
 IrcMessage.RegisterServerMessageType<PotatoMessage>();
 myClient.EventHub.Subscribe<PotatoMessage>((client, args) => Console.WriteLine("Potatoes are cool!"));
 ```
+
+After that you should be good to go!

--- a/docfx_project/articles/event-hub.md
+++ b/docfx_project/articles/event-hub.md
@@ -1,0 +1,37 @@
+# The Event Hub
+
+## Methodology
+The event hub has been substantially rewritten from its origins in NetIRC but provides similar functionality.  
+
+### The Problem
+The original hub had an event for each implementation of `IServerMessage` that was present in the library.  This had the drawbacks of limiting available events to only messages defined within the NetIRC library and added the need for a lot of additional, mostly copy-pasted code to be added for each type of message that is added.  
+
+### My Approach
+To avoid this shortcomings, I changed the event hub to dynamically create and provide event handlers as needed.  This cuts back on the amount of code that must be added for each type of message and means that users of the library can extend its in-built message types with additional ones at runtime.  My background is in web development with MVC so I'm not especially familiar with C# events.  If you have an idea for a nicer way of handling this, please let me know.  
+
+#### Subscribing to an Incoming Message Event
+You can add actions to be taken when a message of a certain type comes in with lambdas or method references.
+```csharp
+myClient.EventHub.Subscribe<PrivateMessage>((client, args) => Console.WriteLine(args.IrcMessage.Message));
+```
+
+### Registering Additional Message Types
+If the type of message you want to listen for isn't in GravyIrc yet, open a pull request!  Please open a pull request :)
+If you want to extend things on your end, I've made it easy to do that was well.  You'll need a class that implements `IServerMessage` and is decorated with a `ServerMessageAttribute`.
+```csharp
+[ServerMessage("POTATO")]
+public class PotatoMessage : IrcMessage, IServerMessage
+{
+    ...
+    public void TriggerEvent(EventHub eventHub)
+    {
+        eventHub.Trigger(this);
+    }
+}
+```
+
+Once you have your class ready, register it to `IrcMessage` so that incoming messages with that command will be converted to your type and you'll be able to subscribe to events for it.
+```csharp
+IrcMessage.RegisterServerMessageType<PotatoMessage>();
+myClient.EventHub.Subscribe<PotatoMessage>((client, args) => Console.WriteLine("Potatoes are cool!"));
+```

--- a/docfx_project/articles/toc.yml
+++ b/docfx_project/articles/toc.yml
@@ -1,2 +1,4 @@
 - name: Introduction
   href: intro.md
+- name: Event Hub
+  href: event-hub.md

--- a/src/GravyIrc/Client.cs
+++ b/src/GravyIrc/Client.cs
@@ -80,14 +80,14 @@ namespace GravyIrc
 
         private void InitializeDefaultEventHubEvents()
         {
-            EventHub.Ping += EventHub_Ping;
-            EventHub.Join += EventHub_Join;
-            EventHub.Part += EventHub_Part;
-            EventHub.Quit += EventHub_Quit;
-            EventHub.Kick += EventHub_Kick;
-            EventHub.PrivMsg += EventHub_PrivMsg;
-            EventHub.RplNamReply += EventHub_RplNamReply;
-            EventHub.Nick += EventHub_Nick;
+            EventHub.AddEventListener<PingMessage>(EventHub_Ping);
+            EventHub.AddEventListener<JoinMessage>(EventHub_Join);
+            EventHub.AddEventListener<PartMessage>(EventHub_Part);
+            EventHub.AddEventListener<QuitMessage>(EventHub_Quit);
+            EventHub.AddEventListener<KickMessage>(EventHub_Kick);
+            EventHub.AddEventListener<PrivateMessage>(EventHub_PrivMsg);
+            EventHub.AddEventListener<RplNamReplyMessage>(EventHub_RplNamReply);
+            EventHub.AddEventListener<NickMessage>(EventHub_Nick);
         }
 
         private void EventHub_Nick(Client client, IrcMessageEventArgs<NickMessage> e)

--- a/src/GravyIrc/Client.cs
+++ b/src/GravyIrc/Client.cs
@@ -80,14 +80,14 @@ namespace GravyIrc
 
         private void InitializeDefaultEventHubEvents()
         {
-            EventHub.AddEventListener<PingMessage>(EventHub_Ping);
-            EventHub.AddEventListener<JoinMessage>(EventHub_Join);
-            EventHub.AddEventListener<PartMessage>(EventHub_Part);
-            EventHub.AddEventListener<QuitMessage>(EventHub_Quit);
-            EventHub.AddEventListener<KickMessage>(EventHub_Kick);
-            EventHub.AddEventListener<PrivateMessage>(EventHub_PrivMsg);
-            EventHub.AddEventListener<RplNamReplyMessage>(EventHub_RplNamReply);
-            EventHub.AddEventListener<NickMessage>(EventHub_Nick);
+            EventHub.Subscribe<PingMessage>(EventHub_Ping);
+            EventHub.Subscribe<JoinMessage>(EventHub_Join);
+            EventHub.Subscribe<PartMessage>(EventHub_Part);
+            EventHub.Subscribe<QuitMessage>(EventHub_Quit);
+            EventHub.Subscribe<KickMessage>(EventHub_Kick);
+            EventHub.Subscribe<PrivateMessage>(EventHub_PrivMsg);
+            EventHub.Subscribe<RplNamReplyMessage>(EventHub_RplNamReply);
+            EventHub.Subscribe<NickMessage>(EventHub_Nick);
         }
 
         private void EventHub_Nick(Client client, IrcMessageEventArgs<NickMessage> e)

--- a/src/GravyIrc/EventHub.cs
+++ b/src/GravyIrc/EventHub.cs
@@ -30,21 +30,46 @@ namespace GravyIrc
             return handler;
         }
 
+        /// <summary>
+        /// Subscribe to incoming messages
+        /// </summary>
+        /// <typeparam name="TMessage">Type of message to subscribe to</typeparam>
+        /// <param name="handler">Action to take when message is received</param>
         public void Subscribe<TMessage>(IrcMessageEventHandler<TMessage> handler) where TMessage : IrcMessage, IServerMessage
         {
             var @event = GetHandler<TMessage>();
             @event.Received += handler;
         }
 
+        /// <summary>
+        /// Unsubscribe from incoming messages
+        /// </summary>
+        /// <typeparam name="TMessage">Type of message to remove subscription on</typeparam>
+        /// <param name="handler">Action to remove</param>
         public void Unsubscribe<TMessage>(IrcMessageEventHandler<TMessage> handler) where TMessage : IrcMessage, IServerMessage
         {
             var @event = GetHandler<TMessage>();
             @event.Received -= handler;
         }
 
+        /// <summary>
+        /// Trigger event handlers for an incoming message
+        /// </summary>
+        /// <typeparam name="TMessage">Type of message</typeparam>
+        /// <param name="args">Information about incoming message</param>
         public void Trigger<TMessage>(IrcMessageEventArgs<TMessage> args) where TMessage : IrcMessage, IServerMessage
         {
             GetHandler<TMessage>()?.OnReceived(args);
+        }
+
+        /// <summary>
+        /// Trigger event handlers for an incoming message
+        /// </summary>
+        /// <typeparam name="TMessage">Type of message</typeparam>
+        /// <param name="message">Incoming message</param>
+        public void Trigger<TMessage>(TMessage message) where TMessage : IrcMessage, IServerMessage
+        {
+            Trigger(new IrcMessageEventArgs<TMessage>(message));
         }
 
         private class ServerMessageEventHandler<TMessage> where TMessage : IrcMessage, IServerMessage

--- a/src/GravyIrc/EventHub.cs
+++ b/src/GravyIrc/EventHub.cs
@@ -1,5 +1,6 @@
 ﻿using GravyIrc.Messages;
 using System;
+using System.Collections.Generic;
 
 namespace GravyIrc
 {
@@ -9,149 +10,51 @@ namespace GravyIrc
     public class EventHub
     {
         private readonly Client client;
+        private readonly Dictionary<Type, object> eventHandlers = new Dictionary<Type, object>();
 
         internal EventHub(Client client)
         {
             this.client = client;
         }
 
-        /// <summary>
-        /// Indicates that we are properly registered on the server
-        /// It happens when the server sends Replies 001 to 004 to a user upon successful registration
-        /// </summary>
-        public event EventHandler RegistrationCompleted;
-        internal void OnRegistrationCompleted()
+        public IrcMessageEventHandler<TMessage> GetEventHandler<TMessage>() where TMessage : IrcMessage, IServerMessage
         {
-            RegistrationCompleted?.Invoke(client, EventArgs.Empty);
+            var messageType = typeof(TMessage);
+            if (eventHandlers.ContainsKey(messageType))
+            {
+                return (eventHandlers[messageType] as ServerMessageEventHandler<TMessage>).Received;
+            }
+
+            var handler = new ServerMessageEventHandler<TMessage>(client);
+            eventHandlers[messageType] = handler;
+            return handler.Received;
         }
 
-        /// <summary>
-        /// Indicates that we received a PING message from the server
-        /// </summary>
-        /// <remarks>The client automatically sends a PONG message response</remarks>
-        public event IrcMessageEventHandler<PingMessage> Ping;
-        internal void OnPing(IrcMessageEventArgs<PingMessage> e)
+        public void AddEventListener<TMessage>(Action<Client, IrcMessageEventArgs<TMessage>> handler) where TMessage : IrcMessage, IServerMessage
         {
-            Ping?.Invoke(client, e);
+            var @event = GetEventHandler<TMessage>();
+            @event += (client, args) => handler(client, args);
         }
 
-        /// <summary>
-        /// Indicates that we received a PRIVMSG message and provides you a PrivMsgMessage object
-        /// </summary>
-        public event IrcMessageEventHandler<PrivateMessage> PrivMsg;
-        internal void OnPrivMsg(IrcMessageEventArgs<PrivateMessage> e)
+        public void TriggerEvent<TMessage>(IrcMessageEventArgs<TMessage> args) where TMessage : IrcMessage, IServerMessage
         {
-            PrivMsg?.Invoke(client, e);
+            GetEventHandler<TMessage>()?.Invoke(client, args);
         }
 
-        /// <summary>
-        /// Indicates that we received a NOTICE message and provides you a NoticeMessage object
-        /// </summary>
-        public event IrcMessageEventHandler<NoticeMessage> Notice;
-        internal void OnNotice(IrcMessageEventArgs<NoticeMessage> e)
+        private class ServerMessageEventHandler<TMessage> where TMessage : IrcMessage, IServerMessage
         {
-            Notice?.Invoke(client, e);
-        }
+            private readonly Client client;
 
-        /// <summary>
-        /// Indicates that some peer changed his Nickname
-        /// </summary>
-        public event IrcMessageEventHandler<NickMessage> Nick;
-        internal void OnNick(IrcMessageEventArgs<NickMessage> e)
-        {
-            Nick?.Invoke(client, e);
-        }
+            internal ServerMessageEventHandler(Client client)
+            {
+                this.client = client;
+            }
 
-        /// <summary>
-        /// Indicates that we received a 001 (RPL_WELCOME) numeric reply message
-        /// </summary>
-        public event IrcMessageEventHandler<RplWelcomeMessage> RplWelcome;
-        internal void OnRplWelcome(IrcMessageEventArgs<RplWelcomeMessage> e)
-        {
-            RplWelcome?.Invoke(client, e);
-            OnRegistrationCompleted();
-        }
-
-        /// <summary>
-        /// Indicates that we received a 002 (RPL_YOURHOST) numeric reply message
-        /// </summary>
-        public event IrcMessageEventHandler<RplYourHostMessage> RplYourHost;
-        internal void OnRplYourHost(IrcMessageEventArgs<RplYourHostMessage> e)
-        {
-            RplYourHost?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that we received a 003 (RPL_CREATED) numeric reply message
-        /// </summary>
-        public event IrcMessageEventHandler<RplCreatedMessage> RplCreated;
-        internal void OnRplCreated(IrcMessageEventArgs<RplCreatedMessage> e)
-        {
-            RplCreated?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that we received a 004 (RPL_MYINFO) numeric reply message
-        /// </summary>
-        public event IrcMessageEventHandler<RplMyInfoMessage> RplMyInfo;
-        internal void OnRplMyInfo(IrcMessageEventArgs<RplMyInfoMessage> e)
-        {
-            RplMyInfo?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that we received a 005 (RPL_ISUPPORT) numeric reply message
-        /// </summary>
-        public event IrcMessageEventHandler<RplISupportMessage> RplISupport;
-        internal void OnRplISupport(IrcMessageEventArgs<RplISupportMessage> e)
-        {
-            RplISupport?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that some peer has joined a channel
-        /// </summary>
-        public event IrcMessageEventHandler<JoinMessage> Join;
-        internal void OnJoin(IrcMessageEventArgs<JoinMessage> e)
-        {
-            Join?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that some peer has left a channel
-        /// </summary>
-        public event IrcMessageEventHandler<PartMessage> Part;
-        internal void OnPart(IrcMessageEventArgs<PartMessage> e)
-        {
-            Part?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates we received a 353 (RPL_NAMREPLY) numeric reply
-        /// which contains the list of all users in a channel
-        /// </summary>
-        public event IrcMessageEventHandler<RplNamReplyMessage> RplNamReply;
-        internal void OnRplNamReply(IrcMessageEventArgs<RplNamReplyMessage> e)
-        {
-            RplNamReply?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that some peer has quit the server
-        /// </summary>
-        public event IrcMessageEventHandler<QuitMessage> Quit;
-        internal void OnQuit(IrcMessageEventArgs<QuitMessage> e)
-        {
-            Quit?.Invoke(client, e);
-        }
-
-        /// <summary>
-        /// Indicates that the bot has been kicked from a channel
-        /// </summary>
-        public event IrcMessageEventHandler<KickMessage> Kick;
-        internal void OnKick(IrcMessageEventArgs<KickMessage> e)
-        {
-            Kick?.Invoke(client, e);
+            public IrcMessageEventHandler<TMessage> Received;
+            internal void OnReceived(IrcMessageEventArgs<TMessage> args)
+            {
+                Received?.Invoke(client, args);
+            }
         }
     }
 }

--- a/src/GravyIrc/EventHub.cs
+++ b/src/GravyIrc/EventHub.cs
@@ -30,15 +30,21 @@ namespace GravyIrc
             return handler;
         }
 
-        public void AddEventListener<TMessage>(Action<Client, IrcMessageEventArgs<TMessage>> handler) where TMessage : IrcMessage, IServerMessage
+        public void Subscribe<TMessage>(IrcMessageEventHandler<TMessage> handler) where TMessage : IrcMessage, IServerMessage
         {
             var @event = GetHandler<TMessage>();
-            @event.Received += (client, args) => handler(client, args);
+            @event.Received += handler;
         }
 
-        public void TriggerEvent<TMessage>(IrcMessageEventArgs<TMessage> args) where TMessage : IrcMessage, IServerMessage
+        public void Unsubscribe<TMessage>(IrcMessageEventHandler<TMessage> handler) where TMessage : IrcMessage, IServerMessage
         {
-            GetHandler<TMessage>()?.Received?.Invoke(client, args);
+            var @event = GetHandler<TMessage>();
+            @event.Received -= handler;
+        }
+
+        public void Trigger<TMessage>(IrcMessageEventArgs<TMessage> args) where TMessage : IrcMessage, IServerMessage
+        {
+            GetHandler<TMessage>()?.OnReceived(args);
         }
 
         private class ServerMessageEventHandler<TMessage> where TMessage : IrcMessage, IServerMessage
@@ -50,7 +56,7 @@ namespace GravyIrc
                 this.client = client;
             }
 
-            public IrcMessageEventHandler<TMessage> Received = (sender, args) => { };
+            public event IrcMessageEventHandler<TMessage> Received;
             internal void OnReceived(IrcMessageEventArgs<TMessage> args)
             {
                 Received?.Invoke(client, args);

--- a/src/GravyIrc/Messages/IRCMessage.cs
+++ b/src/GravyIrc/Messages/IRCMessage.cs
@@ -1,4 +1,5 @@
-﻿using GravyIrc.Extensions;
+﻿using GravyIrc.Attributes;
+using GravyIrc.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,6 +18,29 @@ namespace GravyIrc.Messages
                 .Where(t => interfaceType.IsAssignableFrom(t))
                 .Where(t => t.HasCommand())
                 .ToDictionary(t => t.GetCommand(), t => t);
+        }
+
+        /// <summary>
+        /// Register an additional server message type
+        /// </summary>
+        /// <remarks>Used to extend built-in message types</remarks>
+        /// <typeparam name="TMessage">Type of message to add</typeparam>
+        public static void RegisterServerMessageType<TMessage>() where TMessage : IServerMessage => RegisterServerMessageType(typeof(TMessage));
+
+        /// <summary>
+        /// Register an additional server message type
+        /// </summary>
+        /// <remarks>Used to extend built-in message types</remarks>
+        /// <param name="messageType">Type of message to add</param>
+        public static void RegisterServerMessageType(Type messageType)
+        {
+            var interfaceType = typeof(IServerMessage);
+            if (!interfaceType.IsAssignableFrom(messageType))
+                throw new ArgumentException($"{messageType.FullName} must implement {interfaceType.FullName}");
+            if (!messageType.HasCommand())
+                throw new ArgumentException($"{messageType.FullName} must be annotated with {typeof(ServerMessageAttribute).FullName}");
+
+            ServerMessageTypes[messageType.GetCommand()] = messageType;
         }
 
         public static IServerMessage Create(ParsedIrcMessage parsedMessage)

--- a/src/GravyIrc/Messages/JoinMessage.cs
+++ b/src/GravyIrc/Messages/JoinMessage.cs
@@ -73,7 +73,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<JoinMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<JoinMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/JoinMessage.cs
+++ b/src/GravyIrc/Messages/JoinMessage.cs
@@ -73,7 +73,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<JoinMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/JoinMessage.cs
+++ b/src/GravyIrc/Messages/JoinMessage.cs
@@ -73,7 +73,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnJoin(new IrcMessageEventArgs<JoinMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<JoinMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/KickMessage.cs
+++ b/src/GravyIrc/Messages/KickMessage.cs
@@ -36,7 +36,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<KickMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/KickMessage.cs
+++ b/src/GravyIrc/Messages/KickMessage.cs
@@ -36,7 +36,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnKick(new IrcMessageEventArgs<KickMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<KickMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/KickMessage.cs
+++ b/src/GravyIrc/Messages/KickMessage.cs
@@ -36,7 +36,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<KickMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<KickMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/NickMessage.cs
+++ b/src/GravyIrc/Messages/NickMessage.cs
@@ -24,7 +24,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnNick(new IrcMessageEventArgs<NickMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<NickMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/NickMessage.cs
+++ b/src/GravyIrc/Messages/NickMessage.cs
@@ -24,7 +24,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<NickMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/NickMessage.cs
+++ b/src/GravyIrc/Messages/NickMessage.cs
@@ -24,7 +24,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<NickMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<NickMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/NoticeMessage.cs
+++ b/src/GravyIrc/Messages/NoticeMessage.cs
@@ -48,7 +48,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<NoticeMessage>(this));
+            eventHub.Trigger(this);
         }
 
         public IEnumerable<string> Tokens => new[] { "NOTICE", Target, Message };

--- a/src/GravyIrc/Messages/NoticeMessage.cs
+++ b/src/GravyIrc/Messages/NoticeMessage.cs
@@ -48,7 +48,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnNotice(new IrcMessageEventArgs<NoticeMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<NoticeMessage>(this));
         }
 
         public IEnumerable<string> Tokens => new[] { "NOTICE", Target, Message };

--- a/src/GravyIrc/Messages/NoticeMessage.cs
+++ b/src/GravyIrc/Messages/NoticeMessage.cs
@@ -48,7 +48,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<NoticeMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<NoticeMessage>(this));
         }
 
         public IEnumerable<string> Tokens => new[] { "NOTICE", Target, Message };

--- a/src/GravyIrc/Messages/PartMessage.cs
+++ b/src/GravyIrc/Messages/PartMessage.cs
@@ -60,7 +60,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnPart(new IrcMessageEventArgs<PartMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<PartMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/PartMessage.cs
+++ b/src/GravyIrc/Messages/PartMessage.cs
@@ -60,7 +60,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<PartMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/PartMessage.cs
+++ b/src/GravyIrc/Messages/PartMessage.cs
@@ -60,7 +60,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<PartMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<PartMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/PingMessage.cs
+++ b/src/GravyIrc/Messages/PingMessage.cs
@@ -24,7 +24,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<PingMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/PingMessage.cs
+++ b/src/GravyIrc/Messages/PingMessage.cs
@@ -24,7 +24,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<PingMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<PingMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/PingMessage.cs
+++ b/src/GravyIrc/Messages/PingMessage.cs
@@ -24,7 +24,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnPing(new IrcMessageEventArgs<PingMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<PingMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/PrivateMessage.cs
+++ b/src/GravyIrc/Messages/PrivateMessage.cs
@@ -54,7 +54,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<PrivateMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<PrivateMessage>(this));
         }
 
         /// <summary>

--- a/src/GravyIrc/Messages/PrivateMessage.cs
+++ b/src/GravyIrc/Messages/PrivateMessage.cs
@@ -54,7 +54,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<PrivateMessage>(this));
+            eventHub.Trigger(this);
         }
 
         /// <summary>

--- a/src/GravyIrc/Messages/PrivateMessage.cs
+++ b/src/GravyIrc/Messages/PrivateMessage.cs
@@ -54,7 +54,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnPrivMsg(new IrcMessageEventArgs<PrivateMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<PrivateMessage>(this));
         }
 
         /// <summary>

--- a/src/GravyIrc/Messages/QuitMessage.cs
+++ b/src/GravyIrc/Messages/QuitMessage.cs
@@ -42,7 +42,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<QuitMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/QuitMessage.cs
+++ b/src/GravyIrc/Messages/QuitMessage.cs
@@ -42,7 +42,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnQuit(new IrcMessageEventArgs<QuitMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<QuitMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/QuitMessage.cs
+++ b/src/GravyIrc/Messages/QuitMessage.cs
@@ -42,7 +42,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<QuitMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<QuitMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplCreatedMessage.cs
+++ b/src/GravyIrc/Messages/RplCreatedMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<RplCreatedMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/RplCreatedMessage.cs
+++ b/src/GravyIrc/Messages/RplCreatedMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<RplCreatedMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<RplCreatedMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplCreatedMessage.cs
+++ b/src/GravyIrc/Messages/RplCreatedMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnRplCreated(new IrcMessageEventArgs<RplCreatedMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<RplCreatedMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplISupportMessage.cs
+++ b/src/GravyIrc/Messages/RplISupportMessage.cs
@@ -16,7 +16,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<RplISupportMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/RplISupportMessage.cs
+++ b/src/GravyIrc/Messages/RplISupportMessage.cs
@@ -16,7 +16,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<RplISupportMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<RplISupportMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplISupportMessage.cs
+++ b/src/GravyIrc/Messages/RplISupportMessage.cs
@@ -16,7 +16,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnRplISupport(new IrcMessageEventArgs<RplISupportMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<RplISupportMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplMyInfoMessage.cs
+++ b/src/GravyIrc/Messages/RplMyInfoMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<RplMyInfoMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<RplMyInfoMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplMyInfoMessage.cs
+++ b/src/GravyIrc/Messages/RplMyInfoMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnRplMyInfo(new IrcMessageEventArgs<RplMyInfoMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<RplMyInfoMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplMyInfoMessage.cs
+++ b/src/GravyIrc/Messages/RplMyInfoMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<RplMyInfoMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/RplNamReplyMessage.cs
+++ b/src/GravyIrc/Messages/RplNamReplyMessage.cs
@@ -34,7 +34,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnRplNamReply(new IrcMessageEventArgs<RplNamReplyMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<RplNamReplyMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplNamReplyMessage.cs
+++ b/src/GravyIrc/Messages/RplNamReplyMessage.cs
@@ -34,7 +34,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<RplNamReplyMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/RplNamReplyMessage.cs
+++ b/src/GravyIrc/Messages/RplNamReplyMessage.cs
@@ -34,7 +34,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<RplNamReplyMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<RplNamReplyMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplWelcomeMessage.cs
+++ b/src/GravyIrc/Messages/RplWelcomeMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<RplWelcomeMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<RplWelcomeMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplWelcomeMessage.cs
+++ b/src/GravyIrc/Messages/RplWelcomeMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnRplWelcome(new IrcMessageEventArgs<RplWelcomeMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<RplWelcomeMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplWelcomeMessage.cs
+++ b/src/GravyIrc/Messages/RplWelcomeMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<RplWelcomeMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/src/GravyIrc/Messages/RplYourHostMessage.cs
+++ b/src/GravyIrc/Messages/RplYourHostMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.OnRplYourHost(new IrcMessageEventArgs<RplYourHostMessage>(this));
+            eventHub.TriggerEvent(new IrcMessageEventArgs<RplYourHostMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplYourHostMessage.cs
+++ b/src/GravyIrc/Messages/RplYourHostMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.TriggerEvent(new IrcMessageEventArgs<RplYourHostMessage>(this));
+            eventHub.Trigger(new IrcMessageEventArgs<RplYourHostMessage>(this));
         }
     }
 }

--- a/src/GravyIrc/Messages/RplYourHostMessage.cs
+++ b/src/GravyIrc/Messages/RplYourHostMessage.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Messages
 
         public void TriggerEvent(EventHub eventHub)
         {
-            eventHub.Trigger(new IrcMessageEventArgs<RplYourHostMessage>(this));
+            eventHub.Trigger(this);
         }
     }
 }

--- a/tests/GravyIrc.Tests/ChannelCollectionTests.cs
+++ b/tests/GravyIrc.Tests/ChannelCollectionTests.cs
@@ -13,7 +13,7 @@ namespace GravyIrc.Tests
             collection.Add(channel);
             var channel2 = collection.GetChannel("#test");
 
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
             Assert.Same(channel, channel2);
         }
     }

--- a/tests/GravyIrc.Tests/ClientTests.cs
+++ b/tests/GravyIrc.Tests/ClientTests.cs
@@ -86,7 +86,7 @@ namespace GravyIrc.Tests
             var raw = "PING :xyz.com";
             IrcMessageEventArgs<PingMessage> args = null;
 
-            client.EventHub.AddEventListener<PingMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<PingMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -155,7 +155,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} PRIVMSG {to} :{message}";
             IrcMessageEventArgs<PrivateMessage> args = null;
 
-            client.EventHub.AddEventListener<PrivateMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<PrivateMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -174,7 +174,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} PRIVMSG {to} {message}";
             IrcMessageEventArgs<PrivateMessage> args = null;
 
-            client.EventHub.AddEventListener<PrivateMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<PrivateMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -257,7 +257,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} NOTICE {to} :{message}";
             IrcMessageEventArgs<NoticeMessage> args = null;
 
-            client.EventHub.AddEventListener<NoticeMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<NoticeMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -275,7 +275,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} NOTICE {to} {message}";
             IrcMessageEventArgs<NoticeMessage> args = null;
 
-            client.EventHub.AddEventListener<NoticeMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<NoticeMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -291,7 +291,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 001 NetIRC :{text}";
             IrcMessageEventArgs<RplWelcomeMessage> args = null;
 
-            client.EventHub.AddEventListener<RplWelcomeMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<RplWelcomeMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -312,7 +312,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 002 NetIRC :{text}";
             IrcMessageEventArgs<RplYourHostMessage> args = null;
 
-            client.EventHub.AddEventListener<RplYourHostMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<RplYourHostMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -333,7 +333,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 003 NetIRC :{text}";
             IrcMessageEventArgs<RplCreatedMessage> args = null;
 
-            client.EventHub.AddEventListener<RplCreatedMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<RplCreatedMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -362,7 +362,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 004 {string.Join(" ", parameters)}";
             IrcMessageEventArgs<RplMyInfoMessage> args = null;
 
-            client.EventHub.AddEventListener<RplMyInfoMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<RplMyInfoMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -397,7 +397,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 005 {string.Join(" ", parameters)} :{text}";
             IrcMessageEventArgs<RplISupportMessage> args = null;
 
-            client.EventHub.AddEventListener<RplISupportMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<RplISupportMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -426,7 +426,7 @@ namespace GravyIrc.Tests
             var raw = $":{nick} JOIN {channel}";
             IrcMessageEventArgs<JoinMessage> args = null;
 
-            client.EventHub.AddEventListener<JoinMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<JoinMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -449,7 +449,7 @@ namespace GravyIrc.Tests
             var raw = $":{nick}!~user@x.y.z PART {channel}";
             IrcMessageEventArgs<PartMessage> args = null;
 
-            client.EventHub.AddEventListener<PartMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<PartMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -499,7 +499,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 353 NetIRCConsoleClient = {channel} :NetIRCConsoleClient @Fredi_";
             IrcMessageEventArgs<RplNamReplyMessage> args = null;
 
-            client.EventHub.AddEventListener<RplNamReplyMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<RplNamReplyMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -556,7 +556,7 @@ namespace GravyIrc.Tests
             var raw = $":{nick}!~host@x.y.z QUIT :{message}";
             IrcMessageEventArgs<QuitMessage> args = null;
 
-            client.EventHub.AddEventListener<QuitMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<QuitMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -584,7 +584,7 @@ namespace GravyIrc.Tests
             var raw = ":irc.server.io 001 netIRCTest :Welcome";
             var completed = false;
 
-            client.EventHub.AddEventListener<RplWelcomeMessage>((c, a) => completed = true);
+            client.EventHub.Subscribe<RplWelcomeMessage>((c, a) => completed = true);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -606,7 +606,7 @@ namespace GravyIrc.Tests
             var raw = $":{oldNick} NICK {newNick}";
             IrcMessageEventArgs<NickMessage> args = null;
 
-            client.EventHub.AddEventListener<NickMessage>((c, a) => args = a);
+            client.EventHub.Subscribe<NickMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 

--- a/tests/GravyIrc.Tests/ClientTests.cs
+++ b/tests/GravyIrc.Tests/ClientTests.cs
@@ -1,6 +1,6 @@
-﻿using Moq;
-using GravyIrc.Connection;
+﻿using GravyIrc.Connection;
 using GravyIrc.Messages;
+using Moq;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -86,7 +86,7 @@ namespace GravyIrc.Tests
             var raw = "PING :xyz.com";
             IrcMessageEventArgs<PingMessage> args = null;
 
-            client.EventHub.Ping += (c, a) => args = a;
+            client.EventHub.AddEventListener<PingMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -155,7 +155,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} PRIVMSG {to} :{message}";
             IrcMessageEventArgs<PrivateMessage> args = null;
 
-            client.EventHub.PrivMsg += (c, a) => args = a;
+            client.EventHub.AddEventListener<PrivateMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -174,7 +174,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} PRIVMSG {to} {message}";
             IrcMessageEventArgs<PrivateMessage> args = null;
 
-            client.EventHub.PrivMsg += (c, a) => args = a;
+            client.EventHub.AddEventListener<PrivateMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -191,7 +191,7 @@ namespace GravyIrc.Tests
 
             RaiseDataReceived(mockConnection, client, raw);
 
-            Assert.Equal(1, client.Peers.Count);
+            Assert.Single(client.Peers);
             Assert.Equal("from", client.Peers[0].Nick);
         }
 
@@ -202,7 +202,7 @@ namespace GravyIrc.Tests
 
             RaiseDataReceived(mockConnection, client, raw);
 
-            Assert.Equal(1, client.Queries.Count);
+            Assert.Single(client.Queries);
             Assert.Equal("from", client.Queries[0].Nick);
             Assert.Equal(client.Peers[0], client.Queries[0].User);
         }
@@ -218,7 +218,7 @@ namespace GravyIrc.Tests
             RaiseDataReceived(mockConnection, client, raw);
 
             var messages = client.Queries[0].Messages;
-            Assert.Equal(1, messages.Count);
+            Assert.Single(messages);
             Assert.Equal(user, messages[0].User);
             Assert.Equal(message, messages[0].Text);
         }
@@ -236,7 +236,7 @@ namespace GravyIrc.Tests
             RaiseDataReceived(mockConnection, client, raw);
 
             var messages = channel.Messages;
-            Assert.Equal(1, messages.Count);
+            Assert.Single(messages);
             Assert.Equal(user, messages[0].User);
             Assert.Equal(message, messages[0].Text);
         }
@@ -257,7 +257,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} NOTICE {to} :{message}";
             IrcMessageEventArgs<NoticeMessage> args = null;
 
-            client.EventHub.Notice += (c, a) => args = a;
+            client.EventHub.AddEventListener<NoticeMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -275,7 +275,7 @@ namespace GravyIrc.Tests
             var raw = $":{from} NOTICE {to} {message}";
             IrcMessageEventArgs<NoticeMessage> args = null;
 
-            client.EventHub.Notice += (c, a) => args = a;
+            client.EventHub.AddEventListener<NoticeMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -291,7 +291,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 001 NetIRC :{text}";
             IrcMessageEventArgs<RplWelcomeMessage> args = null;
 
-            client.EventHub.RplWelcome += (c, a) => args = a;
+            client.EventHub.AddEventListener<RplWelcomeMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -312,7 +312,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 002 NetIRC :{text}";
             IrcMessageEventArgs<RplYourHostMessage> args = null;
 
-            client.EventHub.RplYourHost += (c, a) => args = a;
+            client.EventHub.AddEventListener<RplYourHostMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -333,7 +333,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 003 NetIRC :{text}";
             IrcMessageEventArgs<RplCreatedMessage> args = null;
 
-            client.EventHub.RplCreated += (c, a) => args = a;
+            client.EventHub.AddEventListener<RplCreatedMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -362,7 +362,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 004 {string.Join(" ", parameters)}";
             IrcMessageEventArgs<RplMyInfoMessage> args = null;
 
-            client.EventHub.RplMyInfo += (c, a) => args = a;
+            client.EventHub.AddEventListener<RplMyInfoMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -397,7 +397,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 005 {string.Join(" ", parameters)} :{text}";
             IrcMessageEventArgs<RplISupportMessage> args = null;
 
-            client.EventHub.RplISupport += (c, a) => args = a;
+            client.EventHub.AddEventListener<RplISupportMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -426,7 +426,7 @@ namespace GravyIrc.Tests
             var raw = $":{nick} JOIN {channel}";
             IrcMessageEventArgs<JoinMessage> args = null;
 
-            client.EventHub.Join += (c, a) => args = a;
+            client.EventHub.AddEventListener<JoinMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -449,7 +449,7 @@ namespace GravyIrc.Tests
             var raw = $":{nick}!~user@x.y.z PART {channel}";
             IrcMessageEventArgs<PartMessage> args = null;
 
-            client.EventHub.Part += (c, a) => args = a;
+            client.EventHub.AddEventListener<PartMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -499,7 +499,7 @@ namespace GravyIrc.Tests
             var raw = $":irc.server.net 353 NetIRCConsoleClient = {channel} :NetIRCConsoleClient @Fredi_";
             IrcMessageEventArgs<RplNamReplyMessage> args = null;
 
-            client.EventHub.RplNamReply += (c, a) => args = a;
+            client.EventHub.AddEventListener<RplNamReplyMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -537,7 +537,7 @@ namespace GravyIrc.Tests
 
             RaiseDataReceived(mockConnection, client, $":{nick} PART {channel}");
 
-            Assert.Equal(1, ircChannel.Users.Count);
+            Assert.Single(ircChannel.Users);
             Assert.Equal(nick2, ircChannel.Users[0].Nick);
         }
 
@@ -556,7 +556,7 @@ namespace GravyIrc.Tests
             var raw = $":{nick}!~host@x.y.z QUIT :{message}";
             IrcMessageEventArgs<QuitMessage> args = null;
 
-            client.EventHub.Quit += (c, a) => args = a;
+            client.EventHub.AddEventListener<QuitMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -584,7 +584,7 @@ namespace GravyIrc.Tests
             var raw = ":irc.server.io 001 netIRCTest :Welcome";
             var completed = false;
 
-            client.EventHub.RegistrationCompleted += (c, a) => completed = true;
+            client.EventHub.AddEventListener<RplWelcomeMessage>((c, a) => completed = true);
 
             RaiseDataReceived(mockConnection, client, raw);
 
@@ -606,7 +606,7 @@ namespace GravyIrc.Tests
             var raw = $":{oldNick} NICK {newNick}";
             IrcMessageEventArgs<NickMessage> args = null;
 
-            client.EventHub.Nick += (c, a) => args = a;
+            client.EventHub.AddEventListener<NickMessage>((c, a) => args = a);
 
             RaiseDataReceived(mockConnection, client, raw);
 

--- a/tests/GravyIrc.Tests/QueryCollectionTests.cs
+++ b/tests/GravyIrc.Tests/QueryCollectionTests.cs
@@ -14,7 +14,7 @@ namespace GravyIrc.Tests
             collection.Add(query);
             var query2 = collection.GetQuery(user);
 
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
             Assert.Same(query, query2);
         }
     }

--- a/tests/GravyIrc.Tests/UserCollectionTests.cs
+++ b/tests/GravyIrc.Tests/UserCollectionTests.cs
@@ -13,7 +13,7 @@ namespace GravyIrc.Tests
             collection.Add(user);
             var user2 = collection.GetUser("Test");
 
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
             Assert.Same(user, user2);
         }
     }


### PR DESCRIPTION
# The Event Hub

## Methodology
The [EventHub](/api/GravyIrc.EventHub.html) has been substantially rewritten from its origins in NetIRC but provides similar functionality.  

### The Problem
The original hub had an event for each implementation of [IServerMessage](/api/GravyIrc.Messages.IServerMessage.html) that was present in the library.  This had the drawbacks of limiting available events to only messages defined within the NetIRC library and added the need for a lot of additional, mostly copy-pasted code to be added for each type of message that is added.  

### My Approach
To avoid this shortcomings, I changed the event hub to dynamically create and provide event handlers as needed.  This cuts back on the amount of code that must be added for each type of message and means that users of the library can extend its in-built message types with additional ones at runtime.  My background is in web development with MVC so I'm not especially familiar with C# events.  If you have an idea for a nicer way of handling this, please let me know.  

#### Subscribing to an Incoming Message Event
You can add actions to be taken when a message of a certain type comes in with lambdas or method references.
```csharp
myClient.EventHub.Subscribe<PrivateMessage>((client, args) => Console.WriteLine(args.IrcMessage.Message));
```

### Registering Additional Message Types
If the type of message you want to listen for isn't in GravyIrc yet, open a pull request!  Please open a pull request :)
If you want to extend things on your end, I've made it easy to do that was well.  You'll need a class that implements [IServerMessage](/api/GravyIrc.Messages.IServerMessage.html) and is decorated with a [ServerMessageAttribute](/api/GravyIrc.Attributes.ServerMessageAttribute.html).
```csharp
[ServerMessage("POTATO")]
public class PotatoMessage : IrcMessage, IServerMessage
{
    ...
    public void TriggerEvent(EventHub eventHub)
    {
        eventHub.Trigger(this);
    }
}
```

Once you have your class ready, register it to [IrcMessage](/api/GravyIrc.Messages.IrcMessage.html) so that incoming messages with that command will be converted to your type and you'll be able to subscribe to events for it.
```csharp
IrcMessage.RegisterServerMessageType<PotatoMessage>();
myClient.EventHub.Subscribe<PotatoMessage>((client, args) => Console.WriteLine("Potatoes are cool!"));
```

After that you should be good to go!